### PR TITLE
Don't directly touch AR::Base, but do it via AS.on_load

### DIFF
--- a/lib/guard_against_physical_delete.rb
+++ b/lib/guard_against_physical_delete.rb
@@ -3,7 +3,9 @@ require 'guard_against_physical_delete/physical_delete_error'
 require 'guard_against_physical_delete/relation'
 require 'guard_against_physical_delete/base'
 
-ActiveRecord::Base.send(:include, GuardAgainstPhysicalDelete::Base)
-ActiveRecord::Relation.send(:include, GuardAgainstPhysicalDelete::Relation)
+ActiveSupport.on_load :active_record do
+  ActiveRecord::Base.send(:include, GuardAgainstPhysicalDelete::Base)
+  ActiveRecord::Relation.send(:include, GuardAgainstPhysicalDelete::Relation)
 
-require 'guard_against_physical_delete/support_counter_cache'
+  require 'guard_against_physical_delete/support_counter_cache'
+end


### PR DESCRIPTION
Otherwise, requiring this gem (usually via Bundler) will immediately load AR::Base and trigger all of its initializers, which would slowdown the server startup, spec execution that does not depend on AR, etc.
