### PR TITLE
Stick to RSpec 2.x for now

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ group :development do
   gem "jeweler", "~> 1.8.3"
   gem 'database_cleaner'
 
-  gem 'rspec'
+  gem 'rspec', '< 2.99'
   gem 'simplecov', :platforms => [:ruby_19, :ruby_20, :ruby_21]
   gem 'countdownlatch'
 end


### PR DESCRIPTION
Because `rake spec` fails under RSpec 3. /cc @eudoxa
