### PR TITLE
Fixing Rails 4.1 breakage

### DIFF
--- a/lib/guard_against_physical_delete/support_counter_cache/associations/builder/belongs_to.rb
+++ b/lib/guard_against_physical_delete/support_counter_cache/associations/builder/belongs_to.rb
@@ -43,6 +43,8 @@ module GuardAgainstPhysicalDelete
               def add_counter_cache_callbacks_with_logical_delete(model, reflection)
                 add_counter_cache_callbacks_without_logical_delete model, reflection
 
+                return unless model.logical_delete?
+
                 model.after_update lambda { |record|
                   record.belongs_to_counter_cache_after_logical_delete(reflection)
                   record.belongs_to_counter_cache_after_revive(reflection)


### PR DESCRIPTION
Without this line, updating a model in AR 4.1 fails where the model has no logical_delete column. /cc @eudoxa
