### PR TITLE
Don't connect to DB when defining models

### DIFF
--- a/lib/guard_against_physical_delete/support_counter_cache/associations/builder/belongs_to.rb
+++ b/lib/guard_against_physical_delete/support_counter_cache/associations/builder/belongs_to.rb
@@ -8,7 +8,6 @@ module GuardAgainstPhysicalDelete
               private
               def add_counter_cache_methods_with_logical_delete(mixin)
                 add_counter_cache_methods_without_logical_delete mixin
-                return unless mixin.logical_delete?
                 add_logical_delete_counter_cache_methods(mixin)
               end
               alias_method_chain :add_counter_cache_methods, :logical_delete


### PR DESCRIPTION
Asking `logical_delete?` here makes the app load time slower because `logical_delete?` immediately connects to the DB.
