### PR TITLE
Address warning: ["Gemfile.lock"] are not files

### DIFF
--- a/guard_against_physical_delete.gemspec
+++ b/guard_against_physical_delete.gemspec
@@ -17,7 +17,6 @@ Gem::Specification.new do |s|
   ]
   s.files = [
     "Gemfile",
-    "Gemfile.lock",
     "License.txt",
     "README.rdoc",
     "Rakefile",


### PR DESCRIPTION
RubyGems warns when bundling this gem because this package does no more contain Gemfile.lock since 786b3b72d22840f40b514a339ed39c682bff70c9.
