### PR TITLE
Remove Gemfile.lock because it shouldn't exist

### DIFF
--- a/guard_against_physical_delete.gemspec
+++ b/guard_against_physical_delete.gemspec
@@ -17,7 +17,6 @@ Gem::Specification.new do |s|
   ]
   s.files = [
     "Gemfile",
-    "Gemfile.lock",
     "License.txt",
     "README.rdoc",
     "Rakefile",


### PR DESCRIPTION
```
This prevents bundler from installing bins or native extensions, but that may not affect its functionality.
The validation message from Rubygems was:
["Gemfile.lock"] are not files
```
