### PR TITLE
Fix bug at gemspec: spec -> s

### DIFF
--- a/guard_against_physical_delete.gemspec
+++ b/guard_against_physical_delete.gemspec
@@ -16,9 +16,9 @@ Gem::Specification.new do |s|
   s.rubygems_version = "1.8.15"
   s.summary = "A monkey patch for ActiveRecord to prevent physical deletion."
 
-  spec.metadata["changelog_uri"] = "#{spec.homepage}/blob/master/CHANGELOG.md"
-  spec.metadata["homepage_uri"] = spec.homepage
-  spec.metadata["source_code_uri"] = spec.homepage
+  s.metadata["changelog_uri"] = "#{s.homepage}/blob/master/CHANGELOG.md"
+  s.metadata["homepage_uri"] = s.homepage
+  s.metadata["source_code_uri"] = s.homepage
 
   s.add_runtime_dependency "activerecord", "~> 5"
   s.add_development_dependency "rake", "~> 13"


### PR DESCRIPTION
This is my mistake at https://github.com/cookpad/guard_against_physical_delete/pull/23, sorry!