### PR TITLE
Improve test cases for the current requirements

### DIFF
--- a/spec/guard_against_physical_delete/guard_spec.rb
+++ b/spec/guard_against_physical_delete/guard_spec.rb
@@ -1,111 +1,184 @@
 require 'spec_helper'
 require 'countdownlatch'
 
-shared_examples 'preventing physical delete' do
-  let!(:model)        { model_class.create!(:name => "name") }
-  let(:another_model) { model_class.create!(:name => "name") }
-
-  describe '#delete' do
-    context 'without #physical_delete block' do
-      it { expect { model.delete }.to raise_exception(GuardAgainstPhysicalDelete::PhysicalDeleteError) }
+describe GuardAgainstPhysicalDelete do
+  shared_examples_for 'guard against physical delete' do
+    let(:model) do
+      model_class.create!
     end
 
-    context 'with #physical_delete block' do
-      it { expect { model_class.physical_delete { model.delete } }.to_not raise_exception }
-
-      it 'delete successufly with nesting block' do
-        expect {
-          model_class.physical_delete do
-            model_class.physical_delete { model.delete }
-            another_model.delete
-          end
-        }.to_not raise_exception
+    context 'when model has no deleted_at column' do
+      let(:model_class) do
+        Physical
       end
 
-      context 'multi threading' do
-        it 'does not affect another thread' do
-          latch = CountDownLatch.new 1
+      it do
+        expect { subject }.not_to raise_exception
+      end
+    end
 
-          threads = []
-          threads << Thread.new do
-            model_class.physical_delete do
-              latch.wait
+    context 'when model has deleted_at column' do
+      let(:model_class) do
+        Logical
+      end
 
-              expect { model.delete }.to_not raise_exception
-              model_class.connection.close if model_class.connection.respond_to?('close')
-            end
-          end
+      it do
+        expect { subject }.to raise_exception(GuardAgainstPhysicalDelete::PhysicalDeleteError)
+      end
+    end
 
-          threads << Thread.new do
-            expect { another_model.delete }.to raise_exception(GuardAgainstPhysicalDelete::PhysicalDeleteError)
-            model_class.connection.close if model_class.connection.respond_to?('close')
+    context 'when model has logical_delete_column' do
+      let(:model_class) do
+        RemovedAtLogical
+      end
 
-            latch.countdown!
-          end
-
-          threads.map(&:join)
-        end
+      it do
+        expect { subject }.to raise_exception(GuardAgainstPhysicalDelete::PhysicalDeleteError)
       end
     end
   end
 
-  describe '#delete_all' do
-    context 'without #physical_delete block' do
-      it { expect { model_class.delete_all }.to raise_exception(GuardAgainstPhysicalDelete::PhysicalDeleteError) }
+  describe '.physical_delete' do
+    let(:model1) do
+      Logical.create!
     end
 
-    context 'with #physical_delete block' do
-      it { expect { model_class.physical_delete { model_class.delete_all } }.not_to raise_exception }
+    let(:model2) do
+      Logical.create!
     end
+
+    it 'allows physical delete in given block' do
+      expect do
+        model2.class.physical_delete do
+          model1.class.physical_delete do
+            model1.delete
+          end
+          model2.delete
+        end
+      end.not_to raise_exception
+    end
+
+    context 'with multi threading' do
+      it 'does not affect another thread' do
+        latch = CountDownLatch.new 1
+
+        threads = []
+        threads << Thread.new do
+          model1.class.physical_delete do
+            latch.wait
+
+            expect do
+              model1.delete
+            end.to_not raise_exception
+            model1.class.connection.close if model1.class.connection.respond_to?('close')
+          end
+        end
+
+        threads << Thread.new do
+          expect do
+            model2.delete
+          end.to raise_exception(GuardAgainstPhysicalDelete::PhysicalDeleteError)
+          model1.class.connection.close if model1.class.connection.respond_to?('close')
+
+          latch.countdown!
+        end
+
+        threads.map(&:join)
+      end
+    end
+  end
+
+  describe '.delete_all' do
+    subject do
+      model.class.delete_all
+    end
+
+    include_examples 'guard against physical delete'
+  end
+
+  describe '.delete_all on relation' do
+    subject do
+      model.class.where(id: model.id).delete_all
+    end
+
+    include_examples 'guard against physical delete'
+  end
+
+  describe '.destroy_all' do
+    subject do
+      model.class.destroy_all
+    end
+
+    include_examples 'guard against physical delete'
+  end
+
+  describe '.destroy_all on relation' do
+    subject do
+      model.class.where(id: model.id).destroy_all
+    end
+
+    include_examples 'guard against physical delete'
+  end
+
+  describe '#delete' do
+    subject do
+      model.delete
+    end
+
+    include_examples 'guard against physical delete'
+  end
+
+  describe '#destroy' do
+    subject do
+      model.destroy
+    end
+
+    include_examples 'guard against physical delete'
+  end
+
+  describe '#destroy!' do
+    subject do
+      model.destroy
+    end
+
+    include_examples 'guard against physical delete'
   end
 
   describe '#hard_delete' do
-    it 'do delete record' do
-      expect { model.hard_delete }.to change { model_class.where(:id => model.id).count }.from(1).to(0)
+    subject do
+      model.hard_delete
+    end
+
+    let!(:model) do
+      Logical.create!
+    end
+
+    it 'destroys record in physical_delete block' do
+      expect { subject }.to change { model.class.where(id: model.id).count }.from(1).to(0)
     end
   end
 
   describe '#soft_delete' do
-    it 'set timestamp to delete flag' do
-      column = model_class.logical_delete_column
-      expect { model.soft_delete }.to change { model_class.where("#{column} is not null").count }.from(0).to(1)
+    subject do
+      model.soft_delete
+    end
+
+    let(:model) do
+      Logical.create!
+    end
+
+    it 'sets current time to logical delete column' do
+      expect { subject }.to change { model.reload.deleted_at }.from(nil)
     end
 
     it 'invokes after_save' do
-      model.soft_delete
+      subject
       expect(model).to be_after_saved
     end
 
-    it 'validates fields' do
+    it 'invokes validation' do
       model.name = 'too long name'
-      expect { model.soft_delete }.to raise_exception(ActiveRecord::RecordInvalid)
+      expect { subject }.to raise_exception(ActiveRecord::RecordInvalid)
     end
   end
-end
-
-describe Logical do
-  let(:model_class) { Logical }
-
-  it_should_behave_like 'preventing physical delete'
-end
-
-describe RemovedAtLogical do
-  let(:model_class) { RemovedAtLogical }
-
-  it_should_behave_like 'preventing physical delete'
-end
-
-describe Physical do
-  let(:model) { Physical.create!(:name => "name") }
-
-  describe '#delete' do
-    it { expect { model.delete }.to_not raise_exception }
-  end
-end
-
-describe ActiveRecord::Relation do
-  let!(:model) { Logical.create!(:name => "name") }
-
-  subject { Logical.where(:id => model.id) }
-  it { expect { subject.delete(model.id) }.to raise_exception(GuardAgainstPhysicalDelete::PhysicalDeleteError) }
 end


### PR DESCRIPTION
1. Remove test cases about foreign key change because this gem doesn't support it now
2. Avoid shared_examples for better debuggability (I know it's debatable but please let me make this change...)

Output from `--format documentation`:

```
GuardAgainstPhysicalDelete
  when child is physically deleted
    decrements counter
  when deleted_at child is physically deleted
    raises error (FAILED - 1)
  when removed_at child is physically deleted
    raises error (FAILED - 2)
  when deleted_at child is logically deleted
    decrements counter
  when removed_at child is logically deleted
    decrements counter
  when logically deleted deleted_at child is updated
    does not change counter
  when logically deleted removed_at child is updated
    does not change counter
  when logically deleted deleted_at child is logically undeleted
    increments counter
  when logically deleted removed_at child is logically undeleted
    increments counter
```